### PR TITLE
Pass stdin through to the internal command

### DIFF
--- a/cmd/cryptdo/main.go
+++ b/cmd/cryptdo/main.go
@@ -55,6 +55,7 @@ func main() {
 	}
 
 	cmd := exec.Command(opts.Positional.Command, opts.Positional.Args...)
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/test/smoke.bats
+++ b/test/smoke.bats
@@ -113,3 +113,17 @@ setup() {
 
   [ ! -f input.txt ]
 }
+
+@test "it reads from stdin" {
+  echo "I would like to encrypt this!" > input.txt
+
+  cryptdo-bootstrap --passphrase "password" input.txt
+  rm input.txt
+
+  run bash -c 'set -e; echo "New encrypted stuff" | cryptdo --passphrase "password" -- bash -c "cat - > input.txt"'
+  [ "$status" -eq 0 ]
+
+  run cryptdo --passphrase "password" -- cat input.txt
+  [ "$status" -eq 0 ]
+  [ "$output" = "New encrypted stuff" ]
+}


### PR DESCRIPTION
This change proxies `os.Stdin` from cryptdo to the internal command.
This allows for interactive cryptdo commands such as the following:
`cryptdo -p <passpharse> -- /bin/bash`